### PR TITLE
Add profile adapted from mc-stan.org homepage

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,36 @@
+## About Stan
+[Stan](https://mc-stan.org/) is a state-of-the-art platform for statistical modeling and high-performance statistical computation.
+Thousands of users rely on Stan for statistical modeling, data analysis, and prediction in the social, biological, and physical sciences, engineering, and business.
+
+Users specify log density functions in Stan's probabilistic [programming language](https://github.com/stan-dev/stanc3) and get:
+
+* full Bayesian statistical inference with MCMC sampling (NUTS, HMC)
+
+* approximate Bayesian inference with variational inference (ADVI)
+
+* penalized maximum likelihood estimation with optimization (L-BFGS)
+
+Stan's [math library](https://github.com/stan-dev/math) provides differentiable probability functions & linear algebra (C++ autodiff).
+Additional R packages provide [expression-based linear modeling](https://github.com/stan-dev/rstanarm), (posterior visualization)[https://github.com/stan-dev/bayesplot], and [leave-one-out cross-validation](https://github.com/stan-dev/loo).
+
+## Get Started
+
+Stan interfaces with the most popular data analysis languages (R, Python, shell, MATLAB, Julia, Stata) and runs on all major platforms (Linux, Mac, Windows).
+To get started using Stan begin with the [Installation](https://mc-stan.org/users/interfaces/) and [Documentation](https://mc-stan.org/users/documentation/) pages.
+
+## Helping Out
+
+Stan is an active and open developer community. The `help-wanted` and `good-first-issue` labels in our repositories try to highlight good places to get started, and we're happy to help more on our [forums or Slack](https://mc-stan.org/developers/).
+
+We have projects in C++, Python, R, OCaml, and more. If you want to help build future versions of Stan, we want to help you get started.
+
+## Citing Stan
+
+We appreciate citations for the Stan software because it lets us find out what people have been doing with Stan and motivate further grant funding. See [How to Cite Stan](https://mc-stan.org/users/citations/) for more details.
+
+## Open Code & Reproducible Science
+
+Stan is freedom-respecting, open-source software (new BSD core, some interfaces GPLv3). Stan is associated with NumFOCUS, a 501(c)(3) nonprofit supporting open code and reproducible science, through which you can [help support Stan](https://mc-stan.org/support/).
+
+<p align="center"><a href="http://numfocus.org"><img width="200" src="https://mc-stan.org/images/numfocus.png" /></a>
+</p>

--- a/profile/README.md
+++ b/profile/README.md
@@ -11,7 +11,7 @@ Users specify log density functions in Stan's probabilistic [programming languag
 * penalized maximum likelihood estimation with optimization (L-BFGS)
 
 Stan's [math library](https://github.com/stan-dev/math) provides differentiable probability functions & linear algebra (C++ autodiff).
-Additional R packages provide [expression-based linear modeling](https://github.com/stan-dev/rstanarm), (posterior visualization)[https://github.com/stan-dev/bayesplot], and [leave-one-out cross-validation](https://github.com/stan-dev/loo).
+Additional R packages provide [easy formula syntax to specify linear and generalized linear hierarchical models](https://github.com/stan-dev/rstanarm), [posterior visualization](https://github.com/stan-dev/bayesplot), and [leave-one-out cross-validation](https://github.com/stan-dev/loo).
 
 ## Get Started
 
@@ -22,11 +22,13 @@ To get started using Stan begin with the [Installation](https://mc-stan.org/user
 
 Stan is an active and open developer community. The `help-wanted` and `good-first-issue` labels in our repositories try to highlight good places to get started, and we're happy to help more on our [forums or Slack](https://mc-stan.org/developers/).
 
-We have projects in C++, Python, R, OCaml, and more. If you want to help build future versions of Stan, we want to help you get started.
+We have projects in C++, Python, R, OCaml, and more.
+If you want to help build future versions of Stan, we want to help you get started.
 
 ## Citing Stan
 
-We appreciate citations for the Stan software because it lets us find out what people have been doing with Stan and motivate further grant funding. See [How to Cite Stan](https://mc-stan.org/users/citations/) for more details.
+We appreciate citations for the Stan software because it lets us find out what people have been doing with Stan and motivate further grant funding.
+See [How to Cite Stan](https://mc-stan.org/users/citations/) for more details.
 
 ## Open Code & Reproducible Science
 


### PR DESCRIPTION
This adds a [profile/README.md](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile#adding-a-public-organization-profile-readme) which gets shown on the main https://github.com/stan-dev page.

It's adapted from the homepage at mc-stan.org

Preview here:
https://github.com/stan-dev/.github/blob/profile-draft/profile/README.md


Pinging SGB  members @spinkney @mitzimorris @storopoli @vianeylb @yizhang-yiz